### PR TITLE
利用している theme-techbook のバージョンを固定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "validate": "vivliostyle-theme-scripts validate"
   },
   "dependencies": {
-    "@vivliostyle/theme-base": "latest",
-    "@vivliostyle/theme-techbook": "latest"
+    "@vivliostyle/theme-base": "1.0.1",
+    "@vivliostyle/theme-techbook": "1.0.1"
   },
   "devDependencies": {
     "@vivliostyle/cli": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mitsuharu/vivliostyle-theme-iosdc-pamphlet",
   "description": "It is vivliostyle theme for iOSDC Japan pamphlet",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": "Mitsuharu Emoto <mthr1982@gmail.com>",
   "main": "theme.css",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,8 +72,8 @@ __metadata:
   resolution: "@mitsuharu/vivliostyle-theme-iosdc-pamphlet@workspace:."
   dependencies:
     "@vivliostyle/cli": "npm:^8.16.0"
-    "@vivliostyle/theme-base": "npm:latest"
-    "@vivliostyle/theme-techbook": "npm:latest"
+    "@vivliostyle/theme-base": "npm:1.0.1"
+    "@vivliostyle/theme-techbook": "npm:1.0.1"
     vivliostyle-theme-scripts: "npm:^0.3.5"
   peerDependencies:
     "@vivliostyle/cli": ">=8.16.0"
@@ -733,29 +733,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vivliostyle/theme-base@npm:^2.0.0, @vivliostyle/theme-base@npm:latest":
-  version: 2.0.0
-  resolution: "@vivliostyle/theme-base@npm:2.0.0"
+"@vivliostyle/theme-base@npm:1.0.1, @vivliostyle/theme-base@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@vivliostyle/theme-base@npm:1.0.1"
   peerDependencies:
     "@vivliostyle/cli": ">=7"
   peerDependenciesMeta:
     "@vivliostyle/cli":
       optional: true
-  checksum: 10c0/250ef6a6b602ad428f32c992728a00817163d81f983153eca493cb1dd052fe5c2fd623dbace34c349beacdb254b96126eac202a8042a0fcef6cc28cbb46e6b0d
+  checksum: 10c0/3eb0a24b8d435868c9089936f4819159412907ccd804643d66eb7141fa6e67b4d1985091b6759bebd982569bf6113b97a3f28f1d25ced9c32646444d6e228ee1
   languageName: node
   linkType: hard
 
-"@vivliostyle/theme-techbook@npm:latest":
-  version: 2.0.0
-  resolution: "@vivliostyle/theme-techbook@npm:2.0.0"
+"@vivliostyle/theme-techbook@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@vivliostyle/theme-techbook@npm:1.0.1"
   dependencies:
-    "@vivliostyle/theme-base": "npm:^2.0.0"
+    "@vivliostyle/theme-base": "npm:^1.0.1"
   peerDependencies:
     "@vivliostyle/cli": ">=7"
   peerDependenciesMeta:
     "@vivliostyle/cli":
       optional: true
-  checksum: 10c0/3de70009734f9d80a7953bb5bea1a16921e57c725afbae51d71ecbbba0f5925710f241443227bc4c5e02592e3f983e380d40a89ca82dc968f503b31011c91444
+  checksum: 10c0/df2928835dffd2b10b5e6ba889729ba793cdba56435a661c85144fed4c384f5dd213a29850f3a88e83322741582b26c38a277ea477556d860d5282033c8d0827
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fix #1 

## 変更点

pakage.json で設定しているバージョンを `latest` から `1.0.1` に変更した

```json
  "dependencies": {
    "@vivliostyle/theme-base": "1.0.1",
    "@vivliostyle/theme-techbook": "1.0.1"
  },
```

## 確認

`.vivliostyle/themes/packages/@vivliostyle/theme-techbook` で読み込まれているバージョンが 1.0.1 であるのを確認した。

![スクリーンショット 2024-12-20 14 27 30](https://github.com/user-attachments/assets/702e11d3-fc29-47e3-b3c8-fc3e6333f6c9)
